### PR TITLE
Filter autotag workflow to only tag radarr updates

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -37,7 +37,7 @@ jobs:
         id: find_renovate_commit
         run: |
           git log -n 20 --pretty=format:'%H|%an|%s' | while IFS='|' read -r commit author subject; do
-            if [[ "$author" == "renovate[bot]" && "${subject,,}" == *"docker tag to "* ]]; then
+            if [[ "$author" == "renovate[bot]" && "${subject,,}" == *"docker tag to "* && "${subject,,}" == *"radarr"* ]]; then
               VERSION=$(echo "$subject" | sed -E 's/.*[Dd]ocker tag to (.+)$/\1/')
               echo "new_version=$VERSION" >> $GITHUB_OUTPUT
               echo "commit_hash=$commit" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Essentially same as https://github.com/spatterIight/ansible-role-plex/pull/22

After merging, it would be appreciated if https://github.com/spatterIight/ansible-role-radarr/releases/tag/v3.14.6-0 is manually removed.